### PR TITLE
Set mimeType as text/html for HTML chart snippet responses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,8 @@ server.registerTool(
           content: [
             {
               type: 'text',
-              text: result.htmlSnippet
+              text: result.htmlSnippet,
+              mimeType: "text/html"
             }
           ]
         };


### PR DESCRIPTION
Set the mimeType to "text/html" for HTML chart snippets, to help the chat UI to render the HTML charts correctly